### PR TITLE
Fix souls don't respect Curse of Vanishing & ExcellentEnchants hooks

### DIFF
--- a/src/main/kotlin/dev/faultyfunctions/soulgraves/SoulGraves.kt
+++ b/src/main/kotlin/dev/faultyfunctions/soulgraves/SoulGraves.kt
@@ -1,6 +1,7 @@
 package dev.faultyfunctions.soulgraves
 
 import dev.faultyfunctions.soulgraves.commands.ReloadCommand
+import dev.faultyfunctions.soulgraves.compatibilities.ExcellentEnchantsHook
 import dev.faultyfunctions.soulgraves.compatibilities.VaneEnchantmentsHook
 import dev.faultyfunctions.soulgraves.compatibilities.WorldGuardHook
 import dev.faultyfunctions.soulgraves.database.MySQLDatabase
@@ -72,6 +73,10 @@ class SoulGraves : JavaPlugin() {
 
 		if (SpigotCompatUtils.isPluginLoaded("vane-enchantments")) {
 			VaneEnchantmentsHook.instance.registerEvents()
+		}
+
+		if (SpigotCompatUtils.isPluginLoaded("ExcellentEnchants")) {
+			ExcellentEnchantsHook.instance.registerEvents()
 		}
 
 		// COMMANDS

--- a/src/main/kotlin/dev/faultyfunctions/soulgraves/compatibilities/ExcellentEnchantsHook.kt
+++ b/src/main/kotlin/dev/faultyfunctions/soulgraves/compatibilities/ExcellentEnchantsHook.kt
@@ -1,0 +1,49 @@
+package dev.faultyfunctions.soulgraves.compatibilities
+
+import dev.faultyfunctions.soulgraves.SoulGraves
+import dev.faultyfunctions.soulgraves.api.event.SoulSpawnEvent
+import org.bukkit.Bukkit
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.inventory.ItemStack
+
+class ExcellentEnchantsHook : Listener {
+    companion object {
+        val instance: ExcellentEnchantsHook by lazy { ExcellentEnchantsHook() }
+    }
+
+    fun registerEvents() {
+        SoulGraves.plugin.server.pluginManager.registerEvents(ExcellentEnchantsHook(), SoulGraves.plugin)
+        SoulGraves.plugin.logger.info("[√] ExcellentEnchants hook loaded!")
+    }
+
+    /**
+     * Makes sure soulbound items are not dropped on death
+     */
+    @EventHandler
+    fun onSoulSpawn(event: SoulSpawnEvent) {
+        // STORE SOULBOUND ITEMS
+        val soulboundInventory: MutableList<ItemStack?> = mutableListOf()
+        event.soul.inventory.forEachIndexed { index, item ->
+            if (item != null) {
+                if (item.enchantments.filter { it.key.key.toString() == "minecraft:soulbound" }.isNotEmpty()) {
+                    event.soul.inventory[index] = null
+                    soulboundInventory.add(item)
+                }
+            } else {
+                soulboundInventory.add(null)
+            }
+        }
+
+        // RESTORE SOULBOUND ITEMS 1 TICK LATER
+        if (soulboundInventory.isNotEmpty()) {
+            Bukkit.getScheduler().runTaskLater(SoulGraves.plugin, Runnable {
+                soulboundInventory.forEachIndexed { index, item ->
+                    if (item != null) {
+                        event.player.inventory.setItem(index, item)
+                    }
+                }
+            }, 1L)
+        }
+    }
+}

--- a/src/main/kotlin/dev/faultyfunctions/soulgraves/listeners/PlayerDeathListener.kt
+++ b/src/main/kotlin/dev/faultyfunctions/soulgraves/listeners/PlayerDeathListener.kt
@@ -49,6 +49,7 @@ class PlayerDeathListener() : Listener {
 		val inventory: MutableList<ItemStack?> = mutableListOf()
 		player.inventory.forEach { item ->
 			if (item != null) {
+				if (item.enchantments.filter { it.key.key.toString() == "minecraft:vanishing_curse" }.isNotEmpty()) return@forEach
 				inventory.add(item)
 			} else {
 				inventory.add(null) // This is to make sure we keep the same item slot index when we restore items later

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ description: A unique graves plugin where players collect their souls to retriev
 libraries:
   - com.zaxxer:HikariCP:5.1.0
   - io.lettuce:lettuce-core:6.5.3.RELEASE
-softdepend: [WorldGuard, vane-enchantments]
+softdepend: [WorldGuard, vane-enchantments, ExcellentEnchants]
 commands:
   soulgraves:
     description: Main command for SoulGraves


### PR DESCRIPTION
Changes:
- Add ExcellentEnchants hooks for soulbound enchantment #22
- Fix souls don't respect Curse of Vanishing #17

Known issue:
- When a soulbound enchanted item is the only item in the soul, the soul still spawned

Please check and test to make sure, my test is just a simple functional test.