### PR TITLE
Added mention of SoulGravesBanco under addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Replace `TAG` with the release tag on GitHub of your desired version.
 
 ## Third-Party Addons
 - [SoulGravesPlus](https://github.com/JosTheDude/SoulGravesPlus) by [@JosTheDude](https://github.com/JosTheDude)
+- [SoulGravesBanco](https://github.com/justADeni/SoulGravesBanco) by [@justADeni](https://github.com/justADeni)
 
 ## Roadmap
 * [Make a suggestion!](https://github.com/FaultyFunctions/SoulGraves/issues)


### PR DESCRIPTION
I made a very small plugin called [SoulGravesBanco](https://github.com/justADeni/SoulGravesBanco) that makes Soul Graves and banco compatible. I think this feature ties very nicely into the new `/soulgraves back` command, since If the economy is item-based, and the player lost all their items, they couldn't otherwise pay for the fare back to the grave.

In that light, I'm adding this small section under Addons in case anyone else finds it useful.